### PR TITLE
Add support for providing extra `copts` to the `flex` build.

### DIFF
--- a/flex/flex.bzl
+++ b/flex/flex.bzl
@@ -26,13 +26,14 @@ def flex_toolchain(ctx):
     return ctx.toolchains[FLEX_TOOLCHAIN_TYPE].flex_toolchain
 
 # buildifier: disable=unnamed-macro
-def flex_register_toolchains(version = DEFAULT_VERSION):
+def flex_register_toolchains(version = DEFAULT_VERSION, extra_copts = []):
     check_version(version)
     repo_name = "flex_v{}".format(version)
     if repo_name not in native.existing_rules().keys():
         flex_repository(
             name = repo_name,
             version = version,
+            extra_copts = extra_copts,
         )
     native.register_toolchains("@rules_flex//flex/toolchains:v{}".format(version))
 

--- a/flex/internal/repository.bzl
+++ b/flex/internal/repository.bzl
@@ -53,7 +53,7 @@ cc_library(
         "-DSTDC_HEADERS",
         '-DVERSION="{VERSION}"',
         '-DM4="/bin/false"',
-    ],
+    ] + {EXTRA_COPTS},
     features = ["no_copts_tokenization"],
     visibility = ["//bin:__pkg__"],
 )
@@ -76,6 +76,8 @@ cc_binary(
 
 def _flex_repository(ctx):
     version = ctx.attr.version
+    extra_copts = ctx.attr.extra_copts
+
     _check_version(version)
     source = _VERSION_URLS[version]
 
@@ -94,6 +96,7 @@ def _flex_repository(ctx):
     ctx.file("WORKSPACE", "workspace(name = {name})\n".format(name = repr(ctx.name)))
     ctx.file("BUILD.bazel", _FLEX_BUILD.format(
         VERSION = version,
+        EXTRA_COPTS = extra_copts,
     ))
     ctx.file("bin/BUILD.bazel", _FLEX_BIN_BUILD)
 
@@ -101,5 +104,6 @@ flex_repository = repository_rule(
     _flex_repository,
     attrs = {
         "version": attr.string(mandatory = True),
+        "extra_copts": attr.string_list(),
     },
 )


### PR DESCRIPTION
This is important for users with toolchains that will produce
significant warnings when building. We could try to guess at what flags
would silence these warnings (the same way the current code does for
MSVC), but on non-Windows platforms there are multiple different
compilers and compiler versions all with different warning flags.

Instead, simply provide a way for the caller to thread their own flags
through. They can in turn build whatever compiler detection logic is
desired.

It would be possible to just turn off warnings in a blanket way by
passing the flag `-w` on all non-Windows builds. On one hand, this is
a bit simpler. However, it seems rather inelegant and doesn't seem very
sustainable. As an example of where I expect this will break down is for
folks using Clang on Windows.

See the related PR for M4: https://github.com/jmillikin/rules_m4/pull/7