### PR TITLE
Pull enabled features from ctx.features instead of ctx.attr.features

### DIFF
--- a/flex/rules/flex_cc_library.bzl
+++ b/flex/rules/flex_cc_library.bzl
@@ -45,7 +45,7 @@ def _cc_library(ctx, flex_result):
     cc_feature_configuration = cc_common.configure_features(
         ctx = ctx,
         cc_toolchain = cc_toolchain,
-        requested_features = ctx.attr.features,
+        requested_features = ctx.features,
     )
 
     compile_kwargs = {}


### PR DESCRIPTION
Pull the list of enabled features from [ctx.features](https://bazel.build/rules/lib/builtins/ctx#features) rather than `ctx.attr.features` so that we pick up features enabled on the command line or at the package level as well as those specified on the target itself.