### PR TITLE
Fixed incompatibility issues failing BCR dependents

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,7 +5,9 @@ module(
 )
 
 bazel_dep(name = "rules_m4", version = "0.2.3")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 
+bazel_dep(name = "rules_shell", version = "0.4.0", dev_dependency = True)
 bazel_dep(
     name = "googletest",
     version = "1.12.1",

--- a/flex/internal/BUILD
+++ b/flex/internal/BUILD
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 filegroup(
     name = "bzl_srcs",
     srcs = glob(["*.bzl"]),

--- a/flex/internal/flex_action.bzl
+++ b/flex/internal/flex_action.bzl
@@ -54,7 +54,7 @@ These will be added to the command args immediately before the source file.
     ),
     "_m4_deny_shell": attr.label(
         executable = True,
-        cfg = "host",
+        cfg = "exec",
         default = Label("//flex/internal:m4_deny_shell"),
     ),
 }

--- a/flex/internal/toolchain_alias.bzl
+++ b/flex/internal/toolchain_alias.bzl
@@ -16,6 +16,8 @@
 
 """Shim rule for using Flex in a genrule or cc_library."""
 
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load(
     "//flex:toolchain_type.bzl",
     "FLEX_TOOLCHAIN_TYPE",

--- a/flex/internal/toolchain_info.bzl
+++ b/flex/internal/toolchain_info.bzl
@@ -60,7 +60,7 @@ flex_toolchain_info = rule(
         "flex_tool": attr.label(
             mandatory = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "flex_env": attr.string_dict(),
         "flex_lexer_h": attr.label(

--- a/flex/rules/flex_cc_library.bzl
+++ b/flex/rules/flex_cc_library.bzl
@@ -16,6 +16,8 @@
 
 """Definition of the `flex_cc_library` build rule."""
 
+load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
 load("//flex:toolchain_type.bzl", "flex_toolchain")
 load(
     "//flex/internal:flex_action.bzl",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,3 +1,7 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//flex:flex.bzl", "flex_cc_library")
 
 cc_library(

--- a/tools/stardoc/BUILD
+++ b/tools/stardoc/BUILD
@@ -1,11 +1,27 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+
+# TODO: Required due to https://github.com/bazelbuild/rules_cc/issues/279
+bzl_library(
+    name = "rules_cc_bzl_lib",
+    srcs = ["@rules_cc//cc:bzl_srcs"],
+    deps = [
+        "@rules_cc//cc/common",
+    ],
+)
+
+bzl_library(
+    name = "bzl_lib",
+    srcs = ["//flex:bzl_srcs"],
+    deps = [":rules_cc_bzl_lib"],
+)
 
 stardoc(
     name = "flex_md",
     out = "flex.md",
     header_template = ":header.vm",
     input = "//flex:flex_bzl",
-    deps = ["//flex:bzl_srcs"],
+    deps = [":bzl_lib"],
 )
 
 stardoc(
@@ -13,7 +29,7 @@ stardoc(
     out = "flex_repository_ext.md",
     header_template = ":empty.vm",
     input = "//flex/extensions:flex_repository_ext_bzl",
-    deps = ["//flex:bzl_srcs"],
+    deps = [":bzl_lib"],
 )
 
 # https://github.com/bazelbuild/stardoc/issues/78


### PR DESCRIPTION
This accounts for [incompatible_disable_starlark_host_transitions](https://github.com/bazelbuild/bazel/issues/17032) and [incompatible_autoload_externally](https://github.com/bazelbuild/bazel/issues/23043).