### PR TITLE
feat: backport flex noline fix

### DIFF
--- a/docs/rules_flex.md
+++ b/docs/rules_flex.md
@@ -168,7 +168,7 @@ A [`FlexToolchainInfo`](#FlexToolchainInfo).
 <pre>
 load("@rules_flex//flex:flex.bzl", "flex_repository")
 
-flex_repository(<a href="#flex_repository-name">name</a>, <a href="#flex_repository-extra_copts">extra_copts</a>, <a href="#flex_repository-extra_linkopts">extra_linkopts</a>, <a href="#flex_repository-repo_mapping">repo_mapping</a>, <a href="#flex_repository-version">version</a>)
+flex_repository(<a href="#flex_repository-name">name</a>, <a href="#flex_repository-extra_copts">extra_copts</a>, <a href="#flex_repository-extra_linkopts">extra_linkopts</a>, <a href="#flex_repository-patches">patches</a>, <a href="#flex_repository-repo_mapping">repo_mapping</a>, <a href="#flex_repository-version">version</a>)
 </pre>
 
 Repository rule for Flex.
@@ -194,6 +194,7 @@ flex_repository(
 | <a id="flex_repository-name"></a>name |  A unique name for this repository.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="flex_repository-extra_copts"></a>extra_copts |  Additional C compiler options to use when building Flex.   | List of strings | optional |  `[]`  |
 | <a id="flex_repository-extra_linkopts"></a>extra_linkopts |  Additional linker options to use when building Flex.   | List of strings | optional |  `[]`  |
+| <a id="flex_repository-patches"></a>patches |  A mapping from Flex versions to lists of patch files to apply, relative to the root of the Flex source repository. Each patch should be in standard [unified diff format](https://en.wikipedia.org/wiki/Diff#Unified_format).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> List of strings</a> | optional |  `{"2.6.4": ["//patches:0001-fix-noline-for-top-directives.patch"]}`  |
 | <a id="flex_repository-repo_mapping"></a>repo_mapping |  In `WORKSPACE` context only: a dictionary from local repository name to global repository name. This allows controls over workspace dependency resolution for dependencies of this repository.<br><br>For example, an entry `"@foo": "@bar"` declares that, for any time this repository depends on `@foo` (such as a dependency on `@foo//some:target`, it should actually resolve that dependency within globally-declared `@bar` (`@bar//some:target`).<br><br>This attribute is _not_ supported in `MODULE.bazel` context (when invoking a repository rule inside a module extension's implementation function).   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  |
 | <a id="flex_repository-version"></a>version |  A supported version of Flex.   | String | required |  |
 

--- a/flex/rules/flex_repository.bzl
+++ b/flex/rules/flex_repository.bzl
@@ -135,6 +135,9 @@ def _flex_repository(ctx):
 
     _hardcode_int_max_log10(ctx, version)
 
+    for patch in ctx.attr.patches.get(version, []):
+        ctx.patch(Label(patch), strip = 1)
+
     ctx.file("WORKSPACE", "workspace(name = {name})\n".format(
         name = repr(ctx.name),
     ))
@@ -176,6 +179,19 @@ flex_repository(
         ),
         "extra_linkopts": attr.string_list(
             doc = "Additional linker options to use when building Flex.",
+        ),
+        "patches": attr.string_list_dict(
+            doc = """
+            A mapping from Flex versions to lists of patch files to apply,
+            relative to the root of the Flex source repository. Each patch
+            should be in standard [unified diff
+            format](https://en.wikipedia.org/wiki/Diff#Unified_format).
+            """,
+            default = {
+                "2.6.4": [
+                    "//patches:0001-fix-noline-for-top-directives.patch",
+                ],
+            },
         ),
     },
 )

--- a/patches/0001-fix-noline-for-top-directives.patch
+++ b/patches/0001-fix-noline-for-top-directives.patch
@@ -1,0 +1,44 @@
+From 4f81a7293993211ae31970c5a349565dcd1faf21 Mon Sep 17 00:00:00 2001
+From: Javier Maestro <jjmaestro@ieee.org>
+Date: Fri, 16 May 2025 13:47:11 -0400
+Subject: [PATCH] backport: noline for %top directives
+
+See https://github.com/westes/flex/pull/704
+---
+ src/scan.c | 4 +++-
+ src/scan.l | 4 +++-
+ 2 files changed, 6 insertions(+), 2 deletion(-)
+
+diff --git a/src/scan.c b/src/scan.c
+index 66db864..5e750fb 100644
+--- a/src/scan.c
++++ b/src/scan.c
+@@ -2326,7 +2326,9 @@
+ {
+                 brace_start_line = linenum;
+                 ++linenum;
+-                buf_linedir( &top_buf, infilename?infilename:"<stdin>", linenum);
++                // backporting https://github.com/westes/flex/pull/704/
++                if (gen_line_dirs)
++                  buf_linedir( &top_buf, infilename?infilename:"<stdin>", linenum);
+                 brace_depth = 1;
+                 yy_push_state(CODEBLOCK_MATCH_BRACE);
+             }
+diff --git a/src/scan.l b/src/scan.l
+index 66db864..5e750fb 100644
+--- a/src/scan.l
++++ b/src/scan.l
+@@ -175,7 +175,9 @@ M4QEND      "]""]"
+     ^"%top"[[:blank:]]*"{"[[:blank:]]*{NL}    {
+                 brace_start_line = linenum;
+                 ++linenum;
+-                buf_linedir( &top_buf, infilename?infilename:"<stdin>", linenum);
++                // backporting https://github.com/westes/flex/pull/704/
++                if (gen_line_dirs)
++                  buf_linedir( &top_buf, infilename?infilename:"<stdin>", linenum);
+                 brace_depth = 1;
+                 yy_push_state(CODEBLOCK_MATCH_BRACE);
+             }
+-- 
+2.39.5 (Apple Git-154)
+

--- a/patches/BUILD
+++ b/patches/BUILD
@@ -1,0 +1,5 @@
+filegroup(
+    name = "patches",
+    srcs = glob(["*.patch"]),
+    visibility = ["//:__subpackages__"],
+)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -93,3 +93,20 @@ alias(
     actual = "@rules_flex_testutil//:all_versions",
     tags = ["manual"],
 )
+
+genrule(
+    name = "genrule_noline_top_c",
+    srcs = ["top_c.l"],
+    outs = ["top_c.c"],
+    cmd = "M4=$(M4) $(FLEX) --noline --outfile=$@ $(location top_c.l)",
+    toolchains = [
+        "//flex:current_flex_toolchain",
+        "@rules_m4//m4:current_m4_toolchain",
+    ],
+)
+
+sh_test(
+    name = "flex_noline_test",
+    srcs = ["flex_noline_test.sh"],
+    data = [":genrule_noline_top_c"],
+)

--- a/tests/flex_noline_test.sh
+++ b/tests/flex_noline_test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+grep -E '#line [0-9]+' "$RUNFILES_DIR/$TEST_WORKSPACE/tests/top_c.c" || exit 0
+exit 1

--- a/tests/top_c.l
+++ b/tests/top_c.l
@@ -1,0 +1,14 @@
+%top{
+#include <stdio.h>
+}
+
+%%
+
+[0-9]+   { printf("NUMBER: %s\n", yytext); }
+
+%%
+
+int main(void) {
+    yylex();
+    return 0;
+}


### PR DESCRIPTION
When using the --noline flag or the %option noline, flex was failing to suppress the %top line directives.

There was an if-guard missing in the code that adds the line directives to the top_buf. I've fixed it in https://github.com/westes/flex/pull/704.

This commit adds patching capabilities to ease maintaining fixes / backports like the noline fix.

P.S. As [@Smattr mentioned in #268](https://github.com/westes/flex/issues/268#issuecomment-600808716) this fix is important for reproducibility, in Debian and many other projects, like e.g. [in a project I'm working on](https://speakerdeck.com/jjmaestro/reproducible-postgres) (making a reproducible Postgres, amongst other things... that's how I found out about the bug :) )