### PR TITLE
Export `flex_toolchain_info()`

### DIFF
--- a/flex/toolchain_info.bzl
+++ b/flex/toolchain_info.bzl
@@ -1,0 +1,21 @@
+# Copyright 2025 the rules_flex authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for defining a Flex toolchain."""
+
+load("@rules_flex//flex/internal:toolchain_info.bzl", _flex_toolchain_info = "flex_toolchain_info")
+
+flex_toolchain_info = _flex_toolchain_info


### PR DESCRIPTION
Allow the user to define their own `flex` toolchain. For example https://github.com/lexxmark/winflexbison for Windows compatibility.