### PR TITLE
chore: Upgrade `rules_m4` to 0.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_m4",
-    version = "0.2.5",
+    version = "0.3",
 )
 
 bazel_dep(


### PR DESCRIPTION
This change allows `rules_flex` to work in Bazel 9 by addressing the change to external `rules_cc` in the dependency chain.

Fixes: #17